### PR TITLE
rename lsc.ini section from [Lab Config Data] to [Lab Config Sheet]

### DIFF
--- a/docs/mentors/lab-server.rst
+++ b/docs/mentors/lab-server.rst
@@ -98,7 +98,7 @@ content like the following:
 
 .. code-block:: ini
 
-   [Lab Config Data]
+   [Lab Config Sheet]
    email = your-google-account-email@example.com
    password = YOUR_APPLICATION_SPECIFIC_GOOGLE_PASSWORD
    spreadsheet = Lab Server Controller


### PR DESCRIPTION
When executing the command 'show' from the lsc console, the following message is displayed:

> (lsc) show
> No section: 'Lab Config Sheet'
> (lsc)

Also, 'Lab Config Sheet' is the entry in the python config file at 'python-minecraft/lab-server/controller/lsc/config.py'
